### PR TITLE
Update constructor params to uppercase to avoid cascading errors 

### DIFF
--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -237,8 +237,8 @@ namespace Cli
                     Host: new(
                         Cors: new(options.CorsOrigin?.ToArray() ?? Array.Empty<string>()),
                         Authentication: new(
-                            provider: options.AuthenticationProvider,
-                            jwt: (options.Audience is null && options.Issuer is null) ? null : new(options.Audience, options.Issuer)),
+                            Provider: options.AuthenticationProvider,
+                            Jwt: (options.Audience is null && options.Issuer is null) ? null : new(options.Audience, options.Issuer)),
                         Mode: options.HostMode),
                     BaseRoute: runtimeBaseRoute
                 ),

--- a/src/Config/ObjectModel/ApplicationInsightsOptions.cs
+++ b/src/Config/ObjectModel/ApplicationInsightsOptions.cs
@@ -14,10 +14,10 @@ public record ApplicationInsightsOptions
     /// </summary>
     /// <param name="enabled">Indicates whether Application Insights is enabled.</param>
     /// <param name="connectionString">The connection string for Application Insights.</param>
-    public ApplicationInsightsOptions(bool enabled = false, string? connectionString = null)
+    public ApplicationInsightsOptions(bool Enabled = false, string? ConnectionString = null)
     {
-        Enabled = enabled;
-        ConnectionString = connectionString;
+        this.Enabled = Enabled;
+        this.ConnectionString = ConnectionString;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/AuthenticationOptions.cs
+++ b/src/Config/ObjectModel/AuthenticationOptions.cs
@@ -15,12 +15,6 @@ public record AuthenticationOptions
     /// </summary>
     public string Provider { get; set; } = nameof(EasyAuthType.StaticWebApps);
 
-    public AuthenticationOptions(string provider, JwtOptions? jwt)
-    {
-        Provider = provider;
-        Jwt = jwt;
-    }
-
     /// <summary>
     /// Settings enabling validation of the received JWT token.
     /// Required only when Provider is other than EasyAuth.
@@ -58,10 +52,10 @@ public record AuthenticationOptions
     /// With EasyAuth and Simulator, no Audience or Issuer are expected.</param>
     /// <param name="jwt">Settings enabling validation of the received JWT token.
     /// Required only when Provider is other than EasyAuth.</param>
-    public AuthenticationOptions(string provider = nameof(EasyAuthType.StaticWebApps), JwtOptions? jwt = null)
+    public AuthenticationOptions(string Provider = nameof(EasyAuthType.StaticWebApps), JwtOptions? Jwt = null)
     {
-        Provider = provider;
-        Jwt = jwt;
+        this.Provider = Provider;
+        this.Jwt = Jwt;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/CorsOptions.cs
+++ b/src/Config/ObjectModel/CorsOptions.cs
@@ -24,10 +24,10 @@ public record CorsOptions
     /// </summary>
     /// <param name="origins">List of allowed origins.</param>
     /// <param name="allowCredentials">Whether to set Access-Control-Allow-Credentials CORS header.</param>
-    public CorsOptions(string[] origins, bool allowCredentials = false)
+    public CorsOptions(string[] Origins, bool AllowCredentials = false)
     {
-        Origins = origins;
-        AllowCredentials = allowCredentials;
+        this.Origins = Origins;
+        this.AllowCredentials = AllowCredentials;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/CosmosDbNoSQLDataSourceOptions.cs
+++ b/src/Config/ObjectModel/CosmosDbNoSQLDataSourceOptions.cs
@@ -7,7 +7,7 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// The CosmosDB NoSQL connection options.
 /// </summary>
 /// <remarks>This record is mutable.</remarks>
-public record CosmosDbNoSQLDataSourceOptions
+public record CosmosDbNoSQLDataSourceOptions : IDataSourceOptions
 {
     /// <summary>
     /// Name of the default CosmosDB database.
@@ -36,12 +36,12 @@ public record CosmosDbNoSQLDataSourceOptions
     /// <param name="container">Name of the default CosmosDB container.</param>
     /// <param name="schema">Path to the GraphQL schema file.</param>
     /// <param name="graphQLSchema">Raw contents of the GraphQL schema.</param>
-    public CosmosDbNoSQLDataSourceOptions(string? database, string? container, string? schema, string? graphQLSchema)
+    public CosmosDbNoSQLDataSourceOptions(string? Database, string? Container, string? Schema, string? GraphQLSchema)
     {
-        Database = database;
-        Container = container;
-        Schema = schema;
-        GraphQLSchema = graphQLSchema;
+        this.Database = Database;
+        this.Container = Container;
+        this.Schema = Schema;
+        this.GraphQLSchema = GraphQLSchema;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/DataSource.cs
+++ b/src/Config/ObjectModel/DataSource.cs
@@ -44,11 +44,11 @@ public record DataSource
     /// <param name="databaseType">Type of database to use.</param>
     /// <param name="connectionString">Connection string to access the database.</param>
     /// <param name="options">Custom options for the specific database. If there are no options, this could be null.</param>
-    public DataSource(DatabaseType databaseType, string connectionString, Dictionary<string, JsonElement>? options)
+    public DataSource(DatabaseType DatabaseType, string ConnectionString, Dictionary<string, JsonElement>? Options)
     {
-        DatabaseType = databaseType;
-        ConnectionString = connectionString;
-        Options = options;
+        this.DatabaseType = DatabaseType;
+        this.ConnectionString = ConnectionString;
+        this.Options = Options;
     }
 
     /// <summary>
@@ -66,18 +66,18 @@ public record DataSource
         {
             return Options is not null ?
                 (TOptionType)(object)new CosmosDbNoSQLDataSourceOptions(
-                database: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database))),
-                container: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container))),
-                schema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema))),
+                Database: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database))),
+                Container: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container))),
+                Schema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema))),
                 // The "raw" schema will be provided via the controller to setup config, rather than parsed from the JSON file.
-                graphQLSchema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.GraphQLSchema))))
+                GraphQLSchema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.GraphQLSchema))))
                 : default;
         }
 
         if (typeof(TOptionType).IsAssignableFrom(typeof(MsSqlOptions)))
         {
             return (TOptionType)(object)new MsSqlOptions(
-                setSessionContext: ReadBoolOption(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext))));
+                SetSessionContext: ReadBoolOption(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext))));
         }
 
         throw new NotSupportedException($"The type {typeof(TOptionType).FullName} is not a supported strongly typed options object");

--- a/src/Config/ObjectModel/Entity.cs
+++ b/src/Config/ObjectModel/Entity.cs
@@ -43,19 +43,19 @@ public record Entity
     public const string PROPERTY_METHODS = "methods";
 
     public Entity(
-        EntitySource source,
-        EntityGraphQLOptions graphQL,
-        EntityRestOptions rest,
-        EntityPermission[] permissions,
-        Dictionary<string, string>? mappings,
-        Dictionary<string, EntityRelationship>? relationships)
+        EntitySource Source,
+        EntityGraphQLOptions GraphQL,
+        EntityRestOptions Rest,
+        EntityPermission[] Permissions,
+        Dictionary<string, string>? Mappings,
+        Dictionary<string, EntityRelationship>? Relationships)
     {
-        Source = source;
-        GraphQL = graphQL;
-        Rest = rest;
-        Permissions = permissions;
-        Mappings = mappings;
-        Relationships = relationships;
+        this.Source = Source;
+        this.GraphQL = GraphQL;
+        this.Rest = Rest;
+        this.Permissions = Permissions;
+        this.Mappings = Mappings;
+        this.Relationships = Relationships;
     }
 
     public Entity()

--- a/src/Config/ObjectModel/EntityAction.cs
+++ b/src/Config/ObjectModel/EntityAction.cs
@@ -14,11 +14,11 @@ public record EntityAction
     /// <param name="action">The entity action.</param>
     /// <param name="fields">The entity action fields.</param>
     /// <param name="policy">The entity action policy.</param>
-    public EntityAction(EntityActionOperation action, EntityActionFields? fields, EntityActionPolicy? policy)
+    public EntityAction(EntityActionOperation Action, EntityActionFields? Fields, EntityActionPolicy? Policy)
     {
-        Action = action;
-        Fields = fields;
-        Policy = policy;
+        this.Action = Action;
+        this.Fields = Fields;
+        this.Policy = Policy;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/EntityActionFields.cs
+++ b/src/Config/ObjectModel/EntityActionFields.cs
@@ -26,10 +26,10 @@ public record EntityActionFields
     /// </summary>
     /// <param name="exclude">The fields to exclude.</param>
     /// <param name="include">The fields to include.</param>
-    public EntityActionFields(HashSet<string> exclude, HashSet<string>? include = null)
+    public EntityActionFields(HashSet<string> Exclude, HashSet<string>? Include = null)
     {
-        Exclude = exclude;
-        Include = include;
+        this.Exclude = Exclude;
+        this.Include = Include;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/EntityActionPolicy.cs
+++ b/src/Config/ObjectModel/EntityActionPolicy.cs
@@ -15,10 +15,10 @@ public record EntityActionPolicy
     /// </summary>
     /// <param name="request">The request.</param>
     /// <param name="database">The database.</param>
-    public EntityActionPolicy(string? request = null, string? database = null)
+    public EntityActionPolicy(string? Request = null, string? Database = null)
     {
-        Request = request;
-        Database = database;
+        this.Request = Request;
+        this.Database = Database;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/EntityGraphQLOptions.cs
+++ b/src/Config/ObjectModel/EntityGraphQLOptions.cs
@@ -36,12 +36,12 @@ public record EntityGraphQLOptions
     /// <param name="plural">The pluralisation of the entity. If none is provided a pluralisation of the Singular property is used.</param>
     /// <param name="enabled">Indicates if GraphQL is enabled for the entity.</param>
     /// <param name="operation">When the entity maps to a stored procedure, this represents the GraphQL operation to use, otherwise it will be null.</param>
-    public EntityGraphQLOptions(string singular, string plural, bool enabled = true, GraphQLOperation? operation = null)
+    public EntityGraphQLOptions(string Singular, string Plural, bool Enabled = true, GraphQLOperation? Operation = null)
     {
-        Singular = singular;
-        Plural = plural;
-        Enabled = enabled;
-        Operation = operation;
+        this.Singular = Singular;
+        this.Plural = Plural;
+        this.Enabled = Enabled;
+        this.Operation = Operation;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/EntityPermission.cs
+++ b/src/Config/ObjectModel/EntityPermission.cs
@@ -27,10 +27,10 @@ public record EntityPermission
     /// <param name="role">Name of the role to which defined permission applies.</param>
     /// <param name="actions">An array of what can be performed against the entity for the actions.
     /// This can be written in JSON using shorthand notation, or as a full object, with a custom <c>JsonConverter</c> to convert that into the .NET type.</param>
-    public EntityPermission(string role, EntityAction[] actions)
+    public EntityPermission(string Role, EntityAction[] Actions)
     {
-        Role = role;
-        Actions = actions;
+        this.Role = Role;
+        this.Actions = Actions;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/EntityRelationship.cs
+++ b/src/Config/ObjectModel/EntityRelationship.cs
@@ -21,21 +21,21 @@ public record EntityRelationship
     /// <param name="linkingSourceFields">The linking source fields.</param>
     /// <param name="linkingTargetFields">The linking target fields.</param>
     public EntityRelationship(
-        Cardinality cardinality,
-        string targetEntity,
-        string[] sourceFields,
-        string[] targetFields,
-        string? linkingObject,
-        string[] linkingSourceFields,
-        string[] linkingTargetFields)
+        Cardinality Cardinality,
+        string TargetEntity,
+        string[] SourceFields,
+        string[] TargetFields,
+        string? LinkingObject,
+        string[] LinkingSourceFields,
+        string[] LinkingTargetFields)
     {
-        Cardinality = cardinality;
-        TargetEntity = targetEntity;
-        SourceFields = sourceFields;
-        TargetFields = targetFields;
-        LinkingObject = linkingObject;
-        LinkingSourceFields = linkingSourceFields;
-        LinkingTargetFields = linkingTargetFields;
+        this.Cardinality = Cardinality;
+        this.TargetEntity = TargetEntity;
+        this.SourceFields = SourceFields;
+        this.TargetFields = TargetFields;
+        this.LinkingObject = LinkingObject;
+        this.LinkingSourceFields = LinkingSourceFields;
+        this.LinkingTargetFields = LinkingTargetFields;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/EntityRestOptions.cs
+++ b/src/Config/ObjectModel/EntityRestOptions.cs
@@ -37,11 +37,11 @@ public record EntityRestOptions
     /// <param name="methods">The HTTP verbs that are supported for this entity.</param>
     /// <param name="path">The path at which the REST endpoint for this entity is exposed.</param>
     /// <param name="enabled">Whether the entity is enabled for REST.</param>
-    public EntityRestOptions(SupportedHttpVerb[]? methods = null, string? path = null, bool enabled = true)
+    public EntityRestOptions(SupportedHttpVerb[]? Methods = null, string? Path = null, bool Enabled = true)
     {
-        Methods = methods;
-        Path = path;
-        Enabled = enabled;
+        this.Methods = Methods;
+        this.Path = Path;
+        this.Enabled = Enabled;
     }
 
     public EntityRestOptions()

--- a/src/Config/ObjectModel/GraphQLRuntimeOptions.cs
+++ b/src/Config/ObjectModel/GraphQLRuntimeOptions.cs
@@ -14,11 +14,11 @@ public record GraphQLRuntimeOptions
     /// <param name="enabled">Whether the GraphQL runtime is enabled.</param>
     /// <param name="path">The path for the GraphQL endpoint.</param>
     /// <param name="allowIntrospection">Whether introspection is allowed.</param>
-    public GraphQLRuntimeOptions(bool enabled = true, string path = DEFAULT_PATH, bool allowIntrospection = true)
+    public GraphQLRuntimeOptions(bool Enabled = true, string Path = DEFAULT_PATH, bool AllowIntrospection = true)
     {
-        Enabled = enabled;
-        Path = path;
-        AllowIntrospection = allowIntrospection;
+        this.Enabled = Enabled;
+        this.Path = Path;
+        this.AllowIntrospection = AllowIntrospection;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -29,11 +29,11 @@ public record HostOptions
     /// <param name="cors">The CORS options.</param>
     /// <param name="authentication">The authentication options.</param>
     /// <param name="mode">The host mode.</param>
-    public HostOptions(CorsOptions? cors, AuthenticationOptions? authentication, HostMode mode = HostMode.Production)
+    public HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Production)
     {
-        Cors = cors;
-        Authentication = authentication;
-        Mode = mode;
+        this.Cors = Cors;
+        this.Authentication = Authentication;
+        this.Mode = Mode;
     }
 
     /// <summary>
@@ -74,13 +74,13 @@ public record HostOptions
         if (Enum.TryParse<EasyAuthType>(authenticationProvider, ignoreCase: true, out _)
             || AuthenticationOptions.SIMULATOR_AUTHENTICATION.Equals(authenticationProvider))
         {
-            AuthenticationOptions = new(provider: authenticationProvider, jwt: null);
+            AuthenticationOptions = new(Provider: authenticationProvider, Jwt: null);
         }
         else
         {
             AuthenticationOptions = new(
-                provider: authenticationProvider,
-                jwt: new(audience, issuer)
+                Provider: authenticationProvider,
+                Jwt: new(audience, issuer)
             );
         }
 

--- a/src/Config/ObjectModel/JwtOptions.cs
+++ b/src/Config/ObjectModel/JwtOptions.cs
@@ -13,10 +13,10 @@ public record JwtOptions
     /// </summary>
     /// <param name="audience">The audience.</param>
     /// <param name="issuer">The issuer.</param>
-    public JwtOptions(string? audience, string? issuer)
+    public JwtOptions(string? Audience, string? Issuer)
     {
-        Audience = audience;
-        Issuer = issuer;
+        this.Audience = Audience;
+        this.Issuer = Issuer;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/MsSqlOptions.cs
+++ b/src/Config/ObjectModel/MsSqlOptions.cs
@@ -7,15 +7,15 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// Options for MsSql database.
 /// </summary>
 /// <remarks>This record is mutable.</remarks>
-public record MsSqlOptions
+public record MsSqlOptions : IDataSourceOptions
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MsSqlOptions"/> class.
     /// </summary>
     /// <param name="setSessionContext">The value indicating whether to set the session context.</param>
-    public MsSqlOptions(bool setSessionContext = true)
+    public MsSqlOptions(bool SetSessionContext = true)
     {
-        SetSessionContext = setSessionContext;
+        this.SetSessionContext = SetSessionContext;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/RestRuntimeOptions.cs
+++ b/src/Config/ObjectModel/RestRuntimeOptions.cs
@@ -34,11 +34,11 @@ public record RestRuntimeOptions
     /// <param name="enabled">If the REST APIs are enabled.</param>
     /// <param name="path">The URL prefix path at which endpoints for all entities will be exposed.</param>
     /// <param name="requestBodyStrict">Boolean property indicating whether extraneous fields are allowed in request body.</param>
-    public RestRuntimeOptions(bool enabled = true, string path = DEFAULT_PATH, bool requestBodyStrict = true)
+    public RestRuntimeOptions(bool Enabled = true, string Path = DEFAULT_PATH, bool RequestBodyStrict = true)
     {
-        Enabled = enabled;
-        Path = path;
-        RequestBodyStrict = requestBodyStrict;
+        this.Enabled = Enabled;
+        this.Path = Path;
+        this.RequestBodyStrict = RequestBodyStrict;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/RuntimeEntities.cs
+++ b/src/Config/ObjectModel/RuntimeEntities.cs
@@ -81,7 +81,7 @@ public record RuntimeEntities : IEnumerable<KeyValuePair<string, Entity>>
         {
             nameCorrectedEntity = nameCorrectedEntity
                 with
-            { GraphQL = new(singular: entityName, plural: string.Empty) };
+            { GraphQL = new(Singular: entityName, Plural: string.Empty) };
         }
 
         // If no Singular version of the entity name was provided, use the Entity Name from the config
@@ -132,7 +132,7 @@ public record RuntimeEntities : IEnumerable<KeyValuePair<string, Entity>>
                     nameCorrectedEntity
                         with
                     // Unless explicilty configured through config file, REST endpoints are enabled for entities backed by tables/views.
-                    { Rest = new EntityRestOptions(enabled: true) };
+                    { Rest = new EntityRestOptions(Enabled: true) };
         }
         else if (nameCorrectedEntity.Source.Type is EntitySourceType.StoredProcedure && (nameCorrectedEntity.Rest.Methods is null || nameCorrectedEntity.Rest.Methods.Length == 0))
         {
@@ -141,7 +141,7 @@ public record RuntimeEntities : IEnumerable<KeyValuePair<string, Entity>>
             // enabled by default unless otherwise specified.
             // When the Methods property is configured in the config file, the parser correctly parses and populates the methods configured.
             // However, when absent in the config file, REST methods that are enabled by default needs to be populated.
-            nameCorrectedEntity = nameCorrectedEntity with { Rest = new EntityRestOptions(methods: EntityRestOptions.DEFAULT_HTTP_VERBS_ENABLED_FOR_SP, path: nameCorrectedEntity.Rest.Path, enabled: nameCorrectedEntity.Rest.Enabled) };
+            nameCorrectedEntity = nameCorrectedEntity with { Rest = new EntityRestOptions(Methods: EntityRestOptions.DEFAULT_HTTP_VERBS_ENABLED_FOR_SP, Path: nameCorrectedEntity.Rest.Path, Enabled: nameCorrectedEntity.Rest.Enabled) };
         }
 
         return nameCorrectedEntity;

--- a/src/Config/ObjectModel/RuntimeOptions.cs
+++ b/src/Config/ObjectModel/RuntimeOptions.cs
@@ -17,17 +17,17 @@ public record RuntimeOptions
     /// <param name="baseRoute">The base route.</param>
     /// <param name="telemetry">The telemetry options.</param>
     public RuntimeOptions(
-        RestRuntimeOptions? rest,
-        GraphQLRuntimeOptions? graphQL,
-        HostOptions? host,
-        string? baseRoute = null,
-        TelemetryOptions? telemetry = null)
+        RestRuntimeOptions? Rest,
+        GraphQLRuntimeOptions? GraphQL,
+        HostOptions? Host,
+        string? BaseRoute = null,
+        TelemetryOptions? Telemetry = null)
     {
-        Rest = rest;
-        GraphQL = graphQL;
-        Host = host;
-        BaseRoute = baseRoute;
-        Telemetry = telemetry;
+        this.Rest = Rest;
+        this.GraphQL = GraphQL;
+        this.Host = Host;
+        this.BaseRoute = BaseRoute;
+        this.Telemetry = Telemetry;
     }
 
     /// <summary>

--- a/src/Service.Tests/Authorization/SimulatorIntegrationTests.cs
+++ b/src/Service.Tests/Authorization/SimulatorIntegrationTests.cs
@@ -114,7 +114,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authorization
             RuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
             RuntimeConfig config = configProvider.GetConfig();
 
-            AuthenticationOptions AuthenticationOptions = new(provider: AuthenticationOptions.SIMULATOR_AUTHENTICATION, null);
+            AuthenticationOptions AuthenticationOptions = new(Provider: AuthenticationOptions.SIMULATOR_AUTHENTICATION, null);
             RuntimeConfig configWithCustomHostMode = config
                 with
             {

--- a/src/Service.Tests/Configuration/AuthenticationConfigValidatorUnitTests.cs
+++ b/src/Service.Tests/Configuration/AuthenticationConfigValidatorUnitTests.cs
@@ -66,8 +66,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 Audience: "12345",
                 Issuer: "https://login.microsoftonline.com/common");
             AuthenticationOptions authNConfig = new(
-                provider: "AzureAD",
-                jwt: jwt);
+                Provider: "AzureAD",
+                Jwt: jwt);
             RuntimeConfig config = CreateRuntimeConfigWithOptionalAuthN(authNConfig);
 
             _mockFileSystem.AddFile(
@@ -115,8 +115,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 Audience: "12345",
                 Issuer: string.Empty);
             AuthenticationOptions authNConfig = new(
-                provider: "AzureAD",
-                jwt: jwt);
+                Provider: "AzureAD",
+                Jwt: jwt);
 
             RuntimeConfig config = CreateRuntimeConfigWithOptionalAuthN(authNConfig);
 
@@ -136,8 +136,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 Audience: string.Empty,
                 Issuer: DEFAULT_ISSUER);
             authNConfig = new(
-                provider: "AzureAD",
-                jwt: jwt);
+                Provider: "AzureAD",
+                Jwt: jwt);
             config = CreateRuntimeConfigWithOptionalAuthN(authNConfig);
 
             Assert.ThrowsException<NotSupportedException>(() =>
@@ -152,7 +152,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             JwtOptions jwt = new(
                 Audience: "12345",
                 Issuer: string.Empty);
-            AuthenticationOptions authNConfig = new(provider: "EasyAuth", jwt: jwt);
+            AuthenticationOptions authNConfig = new(Provider: "EasyAuth", Jwt: jwt);
             RuntimeConfig config = CreateRuntimeConfigWithOptionalAuthN(authNConfig);
 
             _mockFileSystem.AddFile(
@@ -170,7 +170,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             jwt = new(
                 Audience: string.Empty,
                 Issuer: DEFAULT_ISSUER);
-            authNConfig = new(provider: "EasyAuth", jwt: jwt);
+            authNConfig = new(Provider: "EasyAuth", Jwt: jwt);
             config = CreateRuntimeConfigWithOptionalAuthN(authNConfig);
 
             Assert.ThrowsException<NotSupportedException>(() =>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -1562,7 +1562,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
             const string CUSTOM_CONFIG = "custom-config.json";
 
-            AuthenticationOptions AuthenticationOptions = new(provider: EasyAuthType.StaticWebApps.ToString(), null);
+            AuthenticationOptions AuthenticationOptions = new(Provider: EasyAuthType.StaticWebApps.ToString(), null);
             HostOptions staticWebAppsHostOptions = new(null, AuthenticationOptions);
 
             RuntimeOptions runtimeOptions = configuration.Runtime;
@@ -1802,7 +1802,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             RuntimeConfig config = configProvider.GetConfig();
 
             // Setup configuration
-            AuthenticationOptions AuthenticationOptions = new(provider: authType.ToString(), null);
+            AuthenticationOptions AuthenticationOptions = new(Provider: authType.ToString(), null);
             RuntimeOptions runtimeOptions = new(
                 Rest: new(),
                 GraphQL: new(),

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -2014,7 +2014,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
-                    Host: new(Cors: null, Authentication: new(provider: authenticationProvider, jwt: null)),
+                    Host: new(Cors: null, Authentication: new(Provider: authenticationProvider, Jwt: null)),
                     BaseRoute: runtimeBaseRoute
                 ),
                 Entities: new(new Dictionary<string, Entity>())


### PR DESCRIPTION
Avoid cascading errors and changes throughout project: make constructor params upper instead of lowercase like we'd enforce typically with stylecop. This is to promote velocity of development of this project. We can later go in and change casing if desired.